### PR TITLE
Align Registry Online badge to top

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -52,7 +52,7 @@ export default async function DashboardPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
           <p className="text-muted-foreground">


### PR DESCRIPTION
Change flex container alignment from items-center to items-start to top-align the Registry Online badge with Dashboard heading.