### PR TITLE
Fix page shift when vertical scrollbar appears

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -118,6 +118,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scrollbar-gutter: stable;
+  }
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
Add scrollbar-gutter: stable to html element to reserve space for scrollbar, preventing layout shift when content becomes scrollable