### PR TITLE
style: add custom scrollbar styling for dark and light themes

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -121,44 +121,38 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    scrollbar-width: thin;
-    scrollbar-color: oklch(0.7 0 0 / 40%) transparent;
-  }
-  .dark * {
-    scrollbar-color: oklch(0.5 0 0 / 50%) transparent;
   }
   html {
     scrollbar-gutter: stable;
   }
   body {
     @apply bg-background text-foreground;
+    scrollbar-width: thin;
+    scrollbar-color: var(--muted-foreground) transparent;
   }
-  *::-webkit-scrollbar {
+  body::-webkit-scrollbar,
+  .scrollable-container::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
-  *::-webkit-scrollbar-track {
+  body::-webkit-scrollbar-track,
+  .scrollable-container::-webkit-scrollbar-track {
     background: transparent;
   }
-  *::-webkit-scrollbar-thumb {
-    background: oklch(0.7 0 0 / 40%);
+  body::-webkit-scrollbar-thumb,
+  .scrollable-container::-webkit-scrollbar-thumb {
+    background: color-mix(in oklch, var(--muted-foreground) 50%, transparent);
     border-radius: 4px;
     border: 2px solid transparent;
     background-clip: content-box;
   }
-  *::-webkit-scrollbar-thumb:hover {
-    background: oklch(0.6 0 0 / 60%);
+  body::-webkit-scrollbar-thumb:hover,
+  .scrollable-container::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklch, var(--muted-foreground) 70%, transparent);
     background-clip: content-box;
   }
-  .dark *::-webkit-scrollbar-thumb {
-    background: oklch(0.5 0 0 / 50%);
-    background-clip: content-box;
-  }
-  .dark *::-webkit-scrollbar-thumb:hover {
-    background: oklch(0.6 0 0 / 70%);
-    background-clip: content-box;
-  }
-  *::-webkit-scrollbar-corner {
+  body::-webkit-scrollbar-corner,
+  .scrollable-container::-webkit-scrollbar-corner {
     background: transparent;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -121,12 +121,45 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-width: thin;
+    scrollbar-color: oklch(0.7 0 0 / 40%) transparent;
+  }
+  .dark * {
+    scrollbar-color: oklch(0.5 0 0 / 50%) transparent;
   }
   html {
     scrollbar-gutter: stable;
   }
   body {
     @apply bg-background text-foreground;
+  }
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background: oklch(0.7 0 0 / 40%);
+    border-radius: 4px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background: oklch(0.6 0 0 / 60%);
+    background-clip: content-box;
+  }
+  .dark *::-webkit-scrollbar-thumb {
+    background: oklch(0.5 0 0 / 50%);
+    background-clip: content-box;
+  }
+  .dark *::-webkit-scrollbar-thumb:hover {
+    background: oklch(0.6 0 0 / 70%);
+    background-clip: content-box;
+  }
+  *::-webkit-scrollbar-corner {
+    background: transparent;
   }
 }
 


### PR DESCRIPTION
Adds minimalistic, sleek custom scrollbar styling that matches the application's dark and light themes.

## Changes
- Thin 8px scrollbars with rounded thumbs
- Transparent tracks for clean appearance
- Hover states for better UX
- Dark/light theme support using oklch colors
- Cross-browser support (webkit + standard CSS)

Fixes #18

Generated with [Claude Code](https://claude.ai/code)